### PR TITLE
Add AndroidX instead of support library

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSketchViewManager.java
+++ b/android/src/main/java/com/reactlibrary/RNSketchViewManager.java
@@ -2,7 +2,7 @@
 package com.reactlibrary;
 
 import android.graphics.Color;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;


### PR DESCRIPTION
This is a breaking change, because RN<60 won't work since they don't support androidx